### PR TITLE
Normalize slashes in absolute paths

### DIFF
--- a/ostrichcize.php
+++ b/ostrichcize.php
@@ -107,8 +107,8 @@ class Struthio_Camelus {
 
 		foreach ( $slugs as $slug ) {
 			foreach ( $dirs as $dir ) {
-				$path    = trailingslashit( $dir ) . $slug;
-				$paths[] = trailingslashit( $path );
+				$path    = trailingslashit( trailingslashit( $dir ) . $slug );
+				$paths[] = str_replace( array( '/', '\\' ), DIRECTORY_SEPARATOR, $path );
 			}
 		}
 


### PR DESCRIPTION
When originally trying this out, I couldn't get it working and after a little digging, narrowed it down to a couple of things. The version on WordPress.org isn't up to date, so it doesn't have the action for initializing on `muplugins_loaded`. No big deal once I realized what was going on.

The other issue is that the directory separators in WordPress are mixed on Windows, but errors are thrown with the Windows slash, so the strings never match when adding slugs via `ostrichcized_plugins`. The ID3 library in core uses the method in this PR for normalizing paths.

Thanks for the plugin! It really does help.
