### PR TITLE
Include parent theme directory in paths.

### DIFF
--- a/ostrichcize.php
+++ b/ostrichcize.php
@@ -88,7 +88,7 @@ class Struthio_Camelus {
 
 		// Allow the main theme's errors to be suppressed by filtering this value to return (bool) true
 		if ( true === apply_filters( 'ostrichcize_theme', false ) )
-			$this->_paths[] = get_stylesheet_directory();
+			array_push( $this->_paths, get_template_directory(), get_stylesheet_directory() );
 	}
 
 	/**


### PR DESCRIPTION
Previously get_stylesheet_directory() was the only theme directory included in $_paths, which didn't cover the situation where a child theme was active and there was a notice in the parent theme.
